### PR TITLE
Fixed issues with fixtures amount and triggering

### DIFF
--- a/TaskManager/etc/bash/load_fixtures.sh
+++ b/TaskManager/etc/bash/load_fixtures.sh
@@ -5,3 +5,5 @@ sleep 2
 etc/bin/symfony-console kreta:task-manager:fixtures:organizations
 sleep 2
 etc/bin/symfony-console kreta:task-manager:fixtures:projects
+sleep 2
+etc/bin/symfony-console kreta:task-manager:fixtures:tasks

--- a/TaskManager/src/Kreta/TaskManager/Infrastructure/Symfony/Command/ProjectFixturesCommand.php
+++ b/TaskManager/src/Kreta/TaskManager/Infrastructure/Symfony/Command/ProjectFixturesCommand.php
@@ -20,6 +20,7 @@ use Kreta\SharedKernel\Domain\Model\Identity\Uuid;
 use Kreta\TaskManager\Application\Command\Project\CreateProjectCommand;
 use Kreta\TaskManager\Application\Query\Organization\FilterOrganizationsQuery;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -37,7 +38,13 @@ class ProjectFixturesCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        for ($i = 0; $i < 50; ++$i) {
+        $amount = 50;
+        $output->writeln('Loading projects');
+        $progress = new ProgressBar($output, $amount);
+        $progress->start();
+        $i = 0;
+
+        while ($i < $amount) {
             $userId = UserFixturesCommand::USER_IDS[array_rand(UserFixturesCommand::USER_IDS)];
 
             $this->queryBus->handle(
@@ -61,7 +68,10 @@ class ProjectFixturesCommand extends ContainerAwareCommand
                     Uuid::generate()
                 )
             );
+            $i++;
+            $progress->advance();
         }
-        $output->writeln('Project population is successfully done');
+        $progress->finish();
+        $output->writeln('');
     }
 }

--- a/TaskManager/src/Kreta/TaskManager/Infrastructure/Symfony/Command/TaskFixturesCommand.php
+++ b/TaskManager/src/Kreta/TaskManager/Infrastructure/Symfony/Command/TaskFixturesCommand.php
@@ -21,6 +21,7 @@ use Kreta\TaskManager\Application\Query\Organization\OrganizationOfIdQuery;
 use Kreta\TaskManager\Application\Query\Project\FilterProjectsQuery;
 use Kreta\TaskManager\Domain\Model\Project\Task\TaskPriority;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,7 +41,14 @@ class TaskFixturesCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        for ($i = 0; $i < 50; ++$i) {
+        $amount = 50;
+        $output->writeln('');
+        $output->writeln('Loading tasks');
+        $progress = new ProgressBar($output, $amount);
+        $progress->start();
+        $i = 0;
+
+        while ($i < $amount) {
             $userId = UserFixturesCommand::USER_IDS[array_rand(UserFixturesCommand::USER_IDS)];
 
             $this->queryBus->handle(
@@ -70,8 +78,11 @@ class TaskFixturesCommand extends ContainerAwareCommand
                         $project['id']
                     )
                 );
+                $i++;
+                $progress->advance();
             }
         }
-        $output->writeln('Task population is successfully done');
+        $progress->finish();
+        $output->writeln('');
     }
 }


### PR DESCRIPTION
* The amount of project and task fixtures generated was low, no we always ensure 50 of each are created
* Added progress bar to console output for fixtures
* Added missing command to load_fixtures.sh
