### PR TITLE
Keep current organization context in child routes

### DIFF
--- a/CompositeUi/src/Routes.js
+++ b/CompositeUi/src/Routes.js
@@ -19,6 +19,7 @@ import TaskNew from './views/page/task/New';
 import TaskEdit from './views/page/task/Edit';
 import TaskShow from './views/page/task/Show';
 import LoginPage from './views/page/Login';
+import OrganizationRoot from './views/page/organization/Root';
 import OrganizationNew from './views/page/organization/New';
 import OrganizationShow from './views/page/organization/Show';
 import Profile from './views/page/profile/Edit';
@@ -93,16 +94,19 @@ const
         <Route component={Dashboard} path={routes.search()}/>
 
         <Route component={OrganizationNew} path={routes.organization.new()}/>
-        <Route component={OrganizationShow} path={routes.organization.settings(':organization')}/>
 
-        <Route component={ProjectNew} path={routes.project.new(':organization')}/>
-        <Route component={ProjectRoot}>
-          <Route component={TaskNew} path={routes.task.new(':organization', ':project')}/>
-          <Route component={ProjectShow} path={routes.project.show(':organization', ':project')}>
-            <Route component={TaskShow} path={routes.task.show(':organization', ':project', ':task')}/>
-            <Route component={TaskEdit} path={routes.task.edit(':organization', ':project', ':task')}/>
+        <Route component={OrganizationRoot}>
+          <Route component={OrganizationShow} path={routes.organization.show(':organization')}/>
+
+          <Route component={ProjectNew} path={routes.project.new(':organization')}/>
+          <Route component={ProjectRoot}>
+            <Route component={TaskNew} path={routes.task.new(':organization', ':project')}/>
+            <Route component={ProjectShow} path={routes.project.show(':organization', ':project')}>
+              <Route component={TaskShow} path={routes.task.show(':organization', ':project', ':task')}/>
+              <Route component={TaskEdit} path={routes.task.edit(':organization', ':project', ':task')}/>
+            </Route>
+            <Route component={ProjectSettings} path={routes.project.settings(':organization', ':project')}/>
           </Route>
-          <Route component={ProjectSettings} path={routes.project.settings(':organization', ':project')}/>
         </Route>
 
         <Route component={Profile} path={routes.profile.show()}/>

--- a/CompositeUi/src/views/page/organization/Root.js
+++ b/CompositeUi/src/views/page/organization/Root.js
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the Kreta package.
+ *
+ * (c) Beñat Espiña <benatespina@gmail.com>
+ * (c) Gorka Laucirica <gorka.lauzirika@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import CurrentOrganizationActions from './../../../actions/CurrentOrganization';
+
+import React from 'react';
+import {connect} from 'react-redux';
+
+@connect()
+class Root extends React.Component {
+  componentDidMount() {
+    const {params, dispatch} = this.props;
+
+    dispatch(CurrentOrganizationActions.fetchOrganization(params.organization));
+  }
+
+  componentDidUpdate(prevProps) {
+    const
+      {params, dispatch} = this.props;
+
+    if (params.organization !== prevProps.params.organization) {
+      dispatch(CurrentOrganizationActions.fetchOrganization(params.organization));
+    }
+  }
+
+  render() {
+    return (
+      this.props.children
+    );
+  }
+}
+
+export default Root;

--- a/CompositeUi/src/views/page/organization/Show.js
+++ b/CompositeUi/src/views/page/organization/Show.js
@@ -26,15 +26,9 @@ import {Row, RowColumn} from './../../component/Grid';
 import SectionHeader from './../../component/SectionHeader';
 import Thumbnail from './../../component/Thumbnail';
 import ContentMiddleLayout from './../../layout/ContentMiddleLayout';
-import CurrentOrganizationActions from './../../../actions/CurrentOrganization';
 
 @connect(state => ({currentOrganization: state.currentOrganization}))
 class Show extends React.Component {
-  componentDidMount() {
-    const {params, dispatch} = this.props;
-    dispatch(CurrentOrganizationActions.fetchOrganization(params.organization));
-  }
-
   getProjects() {
     const {organization} = this.props.currentOrganization;
 


### PR DESCRIPTION
This boosts performance as organization is cached as far as organization param is not changed from url
