### PR TITLE
Cleared the babel-loader cache

### DIFF
--- a/CompositeUi/etc/bash/update_graph_schema.sh
+++ b/CompositeUi/etc/bash/update_graph_schema.sh
@@ -3,3 +3,4 @@
 cd ../TaskManager
 etc/bin/symfony-console graph:dump-schema --file=../CompositeUi/schema.json
 cd -
+rm -rf node_modules/.cache/babel-loader/*

--- a/etc/docker/node/server_run.sh
+++ b/etc/docker/node/server_run.sh
@@ -4,4 +4,6 @@ until cd /var/www/compositeui && yarn install
 do
     echo "Retrying yarn install"
 done
-yarn run start
+rm -rf node_modules/.cache/babel-loader/*
+echo "Babel loader cache cleared"
+yarn start


### PR DESCRIPTION
Cleared when restarts the node Docker container and when executes the updated graphql schema sh

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no
