### PR TITLE
Use docker-compose extrahosts instead of hardcoding them

### DIFF
--- a/etc/bash/docker.sh
+++ b/etc/bash/docker.sh
@@ -11,8 +11,6 @@ docker-compose exec php bash -c "cd /var/www/identityaccess && composer install 
 docker-compose exec php bash -c "cd /var/www/identityaccess/var && chown www-data:www-data * && rm -rf cache/*"
 docker-compose exec php bash -c "cd /var/www/taskmanager/var && chown www-data:www-data * && rm -rf cache/*"
 docker-compose exec php bash -c "cd /var/www/identityaccess && sh etc/bash/generate_ssh_keys.sh"
-docker-compose exec php bash -c "echo '172.18.0.10 identityaccess.localhost' >> /etc/hosts"
-docker-compose exec php bash -c "echo '172.18.0.10 taskmanager.localhost' >> /etc/hosts"
 docker-compose exec php bash -c "cd /var/www/taskmanager && etc/bin/symfony-console doctrine:da:cr"
 docker-compose exec php bash -c "cd /var/www/taskmanager && etc/bin/symfony-console doctrine:mi:mi --no-interaction"
 docker-compose exec php bash -c "cd /var/www/identityaccess && etc/bin/symfony-console doctrine:da:cr"

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -54,6 +54,9 @@ services:
             - /var/www/identityaccess/var/cache
             - /var/www/identityaccess/var/sessions
             - /var/www/identityaccess/vendor
+        extra_hosts:
+            - "${TASK_MANAGER_HOST}: ${NGINX_CONTAINER_IP}"
+            - "${IDENTITY_ACCESS_HOST}: ${NGINX_CONTAINER_IP}"
     node:
         build: node
         ports:


### PR DESCRIPTION
Add flexibility reading required hosts in docker from env instead of hardcoding them. 

Related to #241, suggested by @uthopiko 